### PR TITLE
Add devcontainer config

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.231.5/containers/julia
+// See https://github.com/julia-vscode/julia-devcontainer/blob/master/Dockerfile for image contents
+{
+	"name": "Julia (Community)",
+	"image": "ghcr.io/julia-vscode/julia-devcontainer",
+	"extensions": ["julialang.language-julia"],
+	"postCreateCommand": "/julia-devcontainer-scripts/postcreate.jl",
+	"remoteUser": "vscode"
+}


### PR DESCRIPTION
This PR adds a `devcontainer.json` configuration file for a Julia development container, with default settings.